### PR TITLE
Ensure `Name` node when checking for parens in `NoParensEmptyInstantiations`

### DIFF
--- a/src/Linters/NoParensEmptyInstantiations.php
+++ b/src/Linters/NoParensEmptyInstantiations.php
@@ -19,6 +19,7 @@ class NoParensEmptyInstantiations extends BaseLinter
         $visitor = new FindingVisitor(function (Node $node) {
             return $node instanceof Node\Expr\New_
                 && empty($node->args)
+                && $node->class instanceof Node\Name
                 && strpos(
                     $this->getCodeLine($node->getAttributes()['startLine']),
                     "new " . $node->class->toString() . '()'

--- a/tests/Linters/NoParensEmptyInstantiationsTest.php
+++ b/tests/Linters/NoParensEmptyInstantiationsTest.php
@@ -37,4 +37,21 @@ file;
 
         $this->assertEmpty($lints);
     }
+
+    /** @test */
+    public function works_when_instantiating_from_variable()
+    {
+        $file = <<<file
+<?php
+
+\$class = Thing::class;
+\$ok = new \$class;
+file;
+
+        $lints = (new TLint)->lint(
+            new NoParensEmptyInstantiations($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 }


### PR DESCRIPTION
closes #14