### PR TITLE
Add linter `NoCompact`

### DIFF
--- a/src/Commands/LintCommand.php
+++ b/src/Commands/LintCommand.php
@@ -23,6 +23,7 @@ use Tighten\Linters\ClassThingsOrder;
 use Tighten\Linters\ImportFacades;
 use Tighten\Linters\MailableMethodsInBuild;
 use Tighten\Linters\ModelMethodOrder;
+use Tighten\Linters\NoCompact;
 use Tighten\Linters\NoDd;
 use Tighten\Linters\NoDocBlocksForMigrationUpDown;
 use Tighten\Linters\NoLeadingSlashesOnRoutePaths;
@@ -261,6 +262,7 @@ class LintCommand extends Command
                 RestControllersMethodOrder::class => '.php',
                 RequestHelperFunctionWherePossible::class => '.php',
                 ApplyMiddlewareInRoutes::class => '.php',
+                NoCompact::class,
             ];
         }
 

--- a/src/Linters/NoCompact.php
+++ b/src/Linters/NoCompact.php
@@ -9,16 +9,16 @@ use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
 
-class NoDd extends BaseLinter
+class NoCompact extends BaseLinter
 {
-    protected $description = 'There should be no calls to `dd()`';
+    protected $description = 'There should be no calls to `compact()` in controllers';
 
     public function lint(Parser $parser)
     {
         $traverser = new NodeTraverser;
 
         $visitor = new FindingVisitor(function (Node $node) {
-            return $node instanceof FuncCall && ! empty($node->name->parts) && $node->name->parts[0] === 'dd';
+            return $node instanceof FuncCall && ! empty($node->name->parts) && $node->name->parts[0] === 'compact';
         });
 
         $traverser->addVisitor($visitor);

--- a/tests/Linters/NoCompactTest.php
+++ b/tests/Linters/NoCompactTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Tighten\Linters\NoCompact;
+use Tighten\TLint;
+
+class NoCompactTest extends TestCase
+{
+    /** @test */
+    public function catches_compact_call()
+    {
+        $file = <<<file
+<?php
+
+\$foo = "abc";
+compact(\$foo);
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoCompact($file)
+        );
+
+        $this->assertEquals(4, $lints[0]->getNode()->getLine());
+    }
+
+    /** @test */
+    public function does_not_trigger_on_compact_call_in_comments()
+    {
+        $file = <<<file
+<?php
+
+\$foo = "abc";
+//compact(\$foo);
+
+/**
+* compact(\$foo);
+*/
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoCompact($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+}


### PR DESCRIPTION
Added a linter to check for calls to `compact()` in controllers, and tests to go with it. Also fixed an error in the `NoDd` lint that would occur when `$node->name->parts` was empty. This PR fixes #33.