### PR TITLE
Handle `use` aliasing

### DIFF
--- a/src/Linters/NoUnusedImports.php
+++ b/src/Linters/NoUnusedImports.php
@@ -63,7 +63,11 @@ class NoUnusedImports extends BaseLinter
 
         if (! empty($useStatements)) {
             $unusedImports = array_filter($useStatements, function (UseUse $node) use ($used) {
-                return ! in_array(last(explode('\\', $node->name->toString())) ?? $node->name->toString(), $used);
+                $nodeName = $node->name->toString();
+                if ($node->alias) {
+                    $nodeName = $node->alias->name;
+                }
+                return ! in_array(last(explode('\\', $nodeName)) ?? $nodeName, $used);
             });
 
             return $unusedImports;

--- a/src/Linters/NoUnusedImports.php
+++ b/src/Linters/NoUnusedImports.php
@@ -38,8 +38,8 @@ class NoUnusedImports extends BaseLinter
             ) {
                 $used[] = $node->extends->toString();
             } elseif ($node instanceof Node\Param
-                && property_exists($node, 'type')
                 && $node->type instanceof Node\Name
+                && property_exists($node, 'type')
             ) {
                 $used[] = $node->type->toString();
             } elseif ($node instanceof Node\Stmt\Catch_ && property_exists($node, 'types')) {

--- a/tests/Linters/NoUnusedImportsTest.php
+++ b/tests/Linters/NoUnusedImportsTest.php
@@ -158,6 +158,27 @@ file;
     }
 
     /** @test */
+    public function does_not_trigger_when_import_is_aliased()
+    {
+        $file = <<<file
+<?php
+
+use Test\ThingA as ThingB;
+
+\$testA = new ThingB;
+\$testB = ThingB::class;
+\$testC = ThingB::make();
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoUnusedImports($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
     public function handles_variable_class_static_const()
     {
         $file = <<<file


### PR DESCRIPTION
Use the node's alias (if available) to check if it's in use. This fixes #49 and fixes #52.