### PR TITLE
Fix issue with === identifying constructor method

### DIFF
--- a/src/Concerns/IdentifiesClassThings.php
+++ b/src/Concerns/IdentifiesClassThings.php
@@ -62,7 +62,7 @@ trait IdentifiesClassThings
 
     private function isConstructor(Stmt $stmt)
     {
-        return $stmt instanceof ClassMethod && ($stmt->name ?? null) == '__construct';
+        return $stmt instanceof ClassMethod && ($stmt->name->name ?? null) === '__construct';
     }
 
     private function isPublicMethod(Stmt $stmt)

--- a/src/Concerns/IdentifiesClassThings.php
+++ b/src/Concerns/IdentifiesClassThings.php
@@ -62,7 +62,7 @@ trait IdentifiesClassThings
 
     private function isConstructor(Stmt $stmt)
     {
-        return $stmt instanceof ClassMethod && ($stmt->name ?? null) === '__construct';
+        return $stmt instanceof ClassMethod && ($stmt->name ?? null) == '__construct';
     }
 
     private function isPublicMethod(Stmt $stmt)

--- a/tests/Linters/ClassThingsOrderTest.php
+++ b/tests/Linters/ClassThingsOrderTest.php
@@ -54,4 +54,34 @@ file;
 
         $this->assertEquals(5, $lints[0]->getNode()->getLine());
     }
+
+    /** @test */
+    function identifies_constructor_method()
+    {
+        $file = <<<file
+<?php
+
+namespace App;
+
+class Thing
+{
+
+    private function __construct(\$foo)
+    {
+        \$foo = "bar";
+    }
+
+    public function bar()
+    {
+        // 
+    }
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new ClassThingsOrder($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 }


### PR DESCRIPTION
## Overview

This PR fixes an issue with the `Concerns\IdentifiesClassThings@isConstructor` method not correctly identifying a constructor. 

The issue stems from the underlying `Stmt` object's attribute `name`. While `$stmt->name` will evaluate to a string because of an underlying `__toString()` method, but that attribute is actually an instance of `PhpParser\Node\Identifier`. When trying to evaluate `$stmt->name === '__construct'`, this will evaluate to `false` because it's a class instance.

My proposed fix changes the identity operator to an equality operator, adding type juggling to resolve `$stmt->name` to a string. An alternate fix is to use `$stmt->name->toString()`, a public function provided by the `Identifier` class, and continue using `===`.

All tests are passing with this change (using Docker).