### PR TITLE
Sort imports alphabetically throughout

### DIFF
--- a/src/Linters/AlphabeticalImports.php
+++ b/src/Linters/AlphabeticalImports.php
@@ -33,7 +33,7 @@ class AlphabeticalImports extends BaseLinter
 
         if (! empty($useStatements)) {
             $importStrings = array_map(function (UseUse $useStatement) {
-                return explode('\\', $useStatement->name->toString())[0] ?? $useStatement->name->toString();
+                return $useStatement->name->toString();
             }, $useStatements);
 
             $alphabetical = $importStrings;

--- a/tests/Linters/AlphabeticalImportsTest.php
+++ b/tests/Linters/AlphabeticalImportsTest.php
@@ -7,13 +7,32 @@ use Tighten\TLint;
 class AlphabeticalImportsTest extends TestCase
 {
     /** @test */
-    function catches_non_alphabetical_imports()
+    function catches_non_alphabetical_imports_at_the_beginning_of_the_string()
     {
         $file = <<<file
 <?php
 
 use B\A as AA;
 use A\Z\Z;
+
+\$ok = 'thing';
+file;
+
+        $lints = (new TLint)->lint(
+            new AlphabeticalImports($file)
+        );
+
+        $this->assertEquals(3, $lints[0]->getNode()->getLine());
+    }
+
+    /** @test */
+    function catches_non_alphabetical_imports_anywhere_in_the_string()
+    {
+        $file = <<<file
+<?php
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 
 \$ok = 'thing';
 file;
@@ -44,8 +63,8 @@ use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Response;
 use function GuzzleHttp\Psr7\stream_for;
 use Illuminate\Contracts\Console\Kernel;
-use Illuminate\Support\Facades\App;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\App;
 use Mockery;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;


### PR DESCRIPTION
This PR adjusts the `AlphabeticalImports` linter to check for alpha sort throughout the entire import strings.

Fixes #107.