### PR TITLE
Allow app-specific presets and linters/formatters

### DIFF
--- a/bin/tlint
+++ b/bin/tlint
@@ -16,6 +16,10 @@ foreach (
     }
 }
 
+if (file_exists($appAutoloader = getcwd() . '/vendor/autoload.php')) {
+    require $appAutoloader;
+}
+
 use Symfony\Component\Console\Application;
 use Tighten\Commands\FormatCommand;
 use Tighten\Commands\LintCommand;

--- a/src/BaseFormatter.php
+++ b/src/BaseFormatter.php
@@ -8,13 +8,18 @@ use PhpParser\Parser;
 class BaseFormatter
 {
     protected $description = 'No Description for Formatter.';
-    protected $extension;
+    protected $filename;
     protected $code;
     protected $codeLines;
 
-    public function __construct($code, $extension = '.php')
+    public static function appliesToPath(string $path): bool
     {
-        $this->extension = $extension;
+        return true;
+    }
+
+    public function __construct($code, $filename = null)
+    {
+        $this->filename = $filename;
         $this->code = $code;
         $this->codeLines = preg_split('/\r\n|\r|\n/', $code);
     }
@@ -39,8 +44,8 @@ class BaseFormatter
         return $this->code;
     }
 
-    public function getExtension()
+    public function getFilename()
     {
-        return $this->extension;
+        return $this->filename;
     }
 }

--- a/src/BaseLinter.php
+++ b/src/BaseLinter.php
@@ -9,21 +9,19 @@ use Tighten\Illuminate\Compilers\BladeCompiler;
 class BaseLinter
 {
     protected $description = 'No Description for Linter.';
-    protected $extension;
+    protected $filename;
     protected $code;
     protected $codeLines;
-
-    public function __construct($code, $extension = '.php')
+    
+    public static function appliesToPath(string $path): bool
     {
-        $this->extension = $extension;
+        return true;
+    }
 
-        if ($extension === '.blade.php') {
-            $bladeCompiler = new BladeCompiler(null, sys_get_temp_dir());
-            $this->code = $bladeCompiler->compileString($code);
-        } else {
-            $this->code = $code;
-        }
-
+    public function __construct($code, $filename = null)
+    {
+        $this->filename = $filename;
+        $this->code = $code;
         $this->codeLines = preg_split('/\r\n|\r|\n/', $code);
     }
 
@@ -68,8 +66,8 @@ class BaseLinter
         return $this->codeLines;
     }
 
-    public function getExtension()
+    public function getFilename()
     {
-        return $this->extension;
+        return $this->filename;
     }
 }

--- a/src/Commands/FormatCommand.php
+++ b/src/Commands/FormatCommand.php
@@ -68,10 +68,10 @@ class FormatCommand extends BaseCommand
         $initialFileContents = file_get_contents($file);
         $formattedFileContents = $initialFileContents;
 
-        foreach ($formatters as $formatterClass => $parseAs) {
+        foreach ($formatters as $formatterClass) {
             $formatterInstance = new $formatterClass(
                 $formattedFileContents,
-                $parseAs
+                $file
             );
 
             try {
@@ -209,11 +209,9 @@ class FormatCommand extends BaseCommand
     {
         $configPath = getcwd() . '/tformat.json';
         $config = new Config(json_decode(is_file($configPath) ? file_get_contents($configPath) : null, true) ?? null);
-
-        $formatters = [
-            AlphabeticalImports::class => '.php',
-        ];
-
-        return $config->filterFormatters($formatters);
+        
+        return array_filter($config->getFormatters(), function($className) use ($path) {
+            return $className::appliesToPath($path);
+        });
     }
 }

--- a/src/Commands/FormatCommand.php
+++ b/src/Commands/FormatCommand.php
@@ -59,7 +59,12 @@ class FormatCommand extends BaseCommand
 
         if (! empty($only = $input->getOption('only'))) {
             $formatters = array_filter($formatters, function($formatter) use ($only) {
-                return false !== strpos($formatter, $only);
+                foreach ($only as $filter) {
+                    if (false !== strpos($formatter, $filter)) {
+                        return true;
+                    }
+                }
+                return false;
             });
         }
 

--- a/src/Commands/FormatCommand.php
+++ b/src/Commands/FormatCommand.php
@@ -57,10 +57,10 @@ class FormatCommand extends BaseCommand
 
         $formatters = $this->getFormatters($file);
 
-        if (! empty($input->getOption('only'))) {
-            $formatters = array_intersect_key($formatters, array_flip(array_map(function ($className) {
-                return 'Tighten\\Formatters\\' . $className;
-            }, $input->getOption('only'))));
+        if (! empty($only = $input->getOption('only'))) {
+            $formatters = array_filter($formatters, function($formatter) use ($only) {
+                return false !== strpos($formatter, $only);
+            });
         }
 
         $tighten = new TFormat;

--- a/src/Commands/LintCommand.php
+++ b/src/Commands/LintCommand.php
@@ -14,43 +14,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
-use Tighten\BaseLinter;
 use Tighten\CustomNode;
 use Tighten\Lint;
-use Tighten\Linters\AlphabeticalImports;
-use Tighten\Linters\ApplyMiddlewareInRoutes;
-use Tighten\Linters\ArrayParametersOverViewWith;
-use Tighten\Linters\ClassThingsOrder;
-use Tighten\Linters\ConcatenationSpacing;
-use Tighten\Linters\ImportFacades;
-use Tighten\Linters\MailableMethodsInBuild;
-use Tighten\Linters\ModelMethodOrder;
-use Tighten\Linters\NewLineAtEndOfFile;
-use Tighten\Linters\NoCompact;
-use Tighten\Linters\NoDd;
-use Tighten\Linters\NoDocBlocksForMigrationUpDown;
-use Tighten\Linters\NoInlineVarDocs;
-use Tighten\Linters\NoJsonDirective;
-use Tighten\Linters\NoLeadingSlashesOnRoutePaths;
-use Tighten\Linters\NoMethodVisibilityInTests;
-use Tighten\Linters\NoParensEmptyInstantiations;
-use Tighten\Linters\NoSpaceAfterBladeDirectives;
-use Tighten\Linters\NoStringInterpolationWithoutBraces;
-use Tighten\Linters\NoUnusedImports;
-use Tighten\Linters\OneLineBetweenClassVisibilityChanges;
-use Tighten\Linters\PureRestControllers;
-use Tighten\Linters\QualifiedNamesOnlyForClassName;
-use Tighten\Linters\RemoveLeadingSlashNamespaces;
-use Tighten\Linters\RequestHelperFunctionWherePossible;
-use Tighten\Linters\RequestValidation;
-use Tighten\Linters\RestControllersMethodOrder;
-use Tighten\Linters\SpaceAfterBladeDirectives;
-use Tighten\Linters\SpaceAfterSoleNotOperator;
-use Tighten\Linters\SpacesAroundBladeRenderContent;
-use Tighten\Linters\TrailingCommasOnArrays;
-use Tighten\Linters\UseAuthHelperOverFacade;
-use Tighten\Linters\UseConfigOverEnv;
-use Tighten\Linters\ViewWithOverArrayParameters;
 use Tighten\TLint;
 
 class LintCommand extends BaseCommand
@@ -93,11 +58,11 @@ class LintCommand extends BaseCommand
         }
         
         $linters = $this->getLinters($file);
-
-        if (! empty($input->getOption('only'))) {
-            $linters = array_intersect_key($linters, array_flip(array_map(function ($className) {
-                return 'Tighten\\Linters\\' . $className;
-            }, $input->getOption('only'))));
+        
+        if (! empty($only = $input->getOption('only'))) {
+            $linters = array_filter($linters, function($formatter) use ($only) {
+                return false !== strpos($formatter, $only);
+            });
         }
 
         $tighten = new TLint;

--- a/src/Commands/LintCommand.php
+++ b/src/Commands/LintCommand.php
@@ -58,10 +58,15 @@ class LintCommand extends BaseCommand
         }
         
         $linters = $this->getLinters($file);
-        
+
         if (! empty($only = $input->getOption('only'))) {
-            $linters = array_filter($linters, function($formatter) use ($only) {
-                return false !== strpos($formatter, $only);
+            $linters = array_filter($linters, function($linter) use ($only) {
+                foreach ($only as $filter) {
+                    if (false !== strpos($linter, $filter)) {
+                        return true;
+                    }
+                }
+                return false;
             });
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -86,9 +86,7 @@ class Config
 
     private function buildFormatterList(array $config): array
     {
-        $formatters = method_exists($this->preset, 'getFormatters')
-            ? $this->normalizeClassList('Tighten\\Formatters\\', $this->preset->getFormatters())
-            : [];
+        $formatters = $this->normalizeClassList('Tighten\\Formatters\\', $this->preset->getFormatters());
 
         $disabled = isset($config['disabled']) && is_array($config['disabled'])
             ? $this->normalizeClassList('Tighten\\Formatters\\', $config['disabled'])

--- a/src/Config.php
+++ b/src/Config.php
@@ -19,7 +19,7 @@ class Config
             $this->excluded = $jsonConfigContents['excluded'];
         }
         
-        $this->linters = $this->buildLinterList($jsonConfigContents);
+        $this->linters = $this->buildLinterList($jsonConfigContents ?? []);
     }
 
     public function filterFormatters(array $formatters)
@@ -83,19 +83,19 @@ class Config
 		    : $namespace . $className;
     }
     
-    private function buildLinterList(array $jsonConfigContents): array
+    private function buildLinterList(array $config): array
     {
         $linters = $this->normalizeClassList('Tighten\\Linters\\', $this->preset->getLinters());
 
-        if (isset($jsonConfigContents['custom']) && is_array($jsonConfigContents['custom'])) {
+        if (isset($config['custom']) && is_array($config['custom'])) {
             $linters = array_merge(
                 $linters, 
-                $this->normalizeClassList('Tighten\\Linters\\', $jsonConfigContents['custom'])
+                $this->normalizeClassList('Tighten\\Linters\\', $config['custom'])
             );
         }
 
-        $disabled = isset($jsonConfigContents['disabled']) && is_array($jsonConfigContents['disabled'])
-            ? $this->normalizeClassList('Tighten\\Linters\\', $jsonConfigContents['disabled'])
+        $disabled = isset($config['disabled']) && is_array($config['disabled'])
+            ? $this->normalizeClassList('Tighten\\Linters\\', $config['disabled'])
             : [];
         
         return array_diff($linters, $disabled);

--- a/src/Config.php
+++ b/src/Config.php
@@ -86,7 +86,9 @@ class Config
 
     private function buildFormatterList(array $config): array
     {
-        $formatters = $this->normalizeClassList('Tighten\\Formatters\\', $this->preset->getFormatters());
+        $formatters = method_exists($this->preset, 'getFormatters')
+            ? $this->normalizeClassList('Tighten\\Formatters\\', $this->preset->getFormatters())
+            : [];
 
         $disabled = isset($config['disabled']) && is_array($config['disabled'])
             ? $this->normalizeClassList('Tighten\\Formatters\\', $config['disabled'])

--- a/src/Linters/ApplyMiddlewareInRoutes.php
+++ b/src/Linters/ApplyMiddlewareInRoutes.php
@@ -7,9 +7,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsControllers;
 
 class ApplyMiddlewareInRoutes extends BaseLinter
 {
+    use LintsControllers;
+    
     protected $description ='Apply middleware in routes (not controllers).';
 
     public function lint(Parser $parser)

--- a/src/Linters/ArrayParametersOverViewWith.php
+++ b/src/Linters/ArrayParametersOverViewWith.php
@@ -8,9 +8,21 @@ use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsControllers;
+use Tighten\Linters\Concerns\LintsRoutesFiles;
 
 class ArrayParametersOverViewWith extends BaseLinter
 {
+    use LintsControllers, LintsRoutesFiles {
+        LintsControllers::appliesToPath as pathIsController;
+        LintsRoutesFiles::appliesToPath as pathIsRoute;
+    }
+    
+    public static function appliesToPath(string $path): bool
+    {
+        return static::pathIsController($path) || static::pathIsRoute($path);
+    }
+
     protected $description = 'Prefer `view(..., [...])` over `view(...)->with(...)`.';
 
     public function lint(Parser $parser)

--- a/src/Linters/ClassThingsOrder.php
+++ b/src/Linters/ClassThingsOrder.php
@@ -36,7 +36,7 @@ class ClassThingsOrder extends BaseLinter
         'magic method',
     ];
 
-    private $tests;
+    protected $tests;
 
     public function __construct($code, $filename = null)
     {

--- a/src/Linters/ClassThingsOrder.php
+++ b/src/Linters/ClassThingsOrder.php
@@ -18,7 +18,7 @@ class ClassThingsOrder extends BaseLinter
     use IdentifiesClassThings;
     use IdentifiesExtends;
 
-    private const THINGS_ORDER = [
+    protected const THINGS_ORDER = [
         'trait use',
         'public static property',
         'protected static property',

--- a/src/Linters/ClassThingsOrder.php
+++ b/src/Linters/ClassThingsOrder.php
@@ -38,9 +38,9 @@ class ClassThingsOrder extends BaseLinter
 
     private $tests;
 
-    public function __construct($code, $extension = '.php')
+    public function __construct($code, $filename = null)
     {
-        parent::__construct($code, $extension);
+        parent::__construct($code, $filename);
 
         $this->setLintDescription('Class "things" should be ordered ' . implode(', ', self::THINGS_ORDER));
 

--- a/src/Linters/Concerns/LintsBladeTemplates.php
+++ b/src/Linters/Concerns/LintsBladeTemplates.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tighten\Linters\Concerns;
+
+trait LintsBladeTemplates
+{
+    public static function appliesToPath(string $path): bool
+    {
+        return strpos($path, '.blade.php') !== false;
+    }
+}

--- a/src/Linters/Concerns/LintsControllers.php
+++ b/src/Linters/Concerns/LintsControllers.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tighten\Linters\Concerns;
+
+trait LintsControllers
+{
+    public static function appliesToPath(string $path): bool
+    {
+        return strpos($path, 'app/Http/Controllers') !== false;
+    }
+}

--- a/src/Linters/Concerns/LintsMailables.php
+++ b/src/Linters/Concerns/LintsMailables.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tighten\Linters\Concerns;
+
+trait LintsMailables
+{
+    public static function appliesToPath(string $path): bool
+    {
+        return true;
+    }
+}

--- a/src/Linters/Concerns/LintsMigrations.php
+++ b/src/Linters/Concerns/LintsMigrations.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tighten\Linters\Concerns;
+
+trait LintsMigrations
+{
+    public static function appliesToPath(string $path): bool
+    {
+        return strpos($path, 'migrations') !== false;
+    }
+}

--- a/src/Linters/Concerns/LintsNonConfigFiles.php
+++ b/src/Linters/Concerns/LintsNonConfigFiles.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tighten\Linters\Concerns;
+
+trait LintsNonConfigFiles
+{
+    public static function appliesToPath(string $path): bool
+    {
+        return strpos($path, '/config/') === false;
+    }
+}

--- a/src/Linters/Concerns/LintsRoutesFiles.php
+++ b/src/Linters/Concerns/LintsRoutesFiles.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tighten\Linters\Concerns;
+
+trait LintsRoutesFiles
+{
+    public static function appliesToPath(string $path): bool
+    {
+        return strpos($path, 'routes') !== false;
+    }
+}

--- a/src/Linters/Concerns/LintsTests.php
+++ b/src/Linters/Concerns/LintsTests.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tighten\Linters\Concerns;
+
+trait LintsTests
+{
+    public static function appliesToPath(string $path): bool
+    {
+        return strpos($path, 'tests') !== false;
+    }
+}

--- a/src/Linters/ImportFacades.php
+++ b/src/Linters/ImportFacades.php
@@ -10,7 +10,7 @@ use Tighten\BaseLinter;
 
 class ImportFacades extends BaseLinter
 {
-    private static $aliases = [
+    protected static $aliases = [
         'App' => 'Illuminate\Support\Facades\App',
         'Artisan' => 'Illuminate\Support\Facades\Artisan',
         'Auth' => 'Illuminate\Support\Facades\Auth',

--- a/src/Linters/MailableMethodsInBuild.php
+++ b/src/Linters/MailableMethodsInBuild.php
@@ -7,9 +7,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsMailables;
 
 class MailableMethodsInBuild extends BaseLinter
 {
+    use LintsMailables;
+
     protected $description = 'Mailable values (from and subject etc) should be set in build().';
 
     public function lint(Parser $parser)

--- a/src/Linters/ModelMethodOrder.php
+++ b/src/Linters/ModelMethodOrder.php
@@ -27,7 +27,7 @@ class ModelMethodOrder extends BaseLinter
 
     protected $description = 'Model method order should be relationships > scopes > accessors > mutators > boot';
 
-    private $tests;
+    protected $tests;
 
     public function __construct($code, $filename = null)
     {

--- a/src/Linters/ModelMethodOrder.php
+++ b/src/Linters/ModelMethodOrder.php
@@ -17,7 +17,7 @@ class ModelMethodOrder extends BaseLinter
     use IdentifiesModelMethodTypes;
     use IdentifiesExtends;
 
-    private const METHOD_ORDER = [
+    protected const METHOD_ORDER = [
         0 => 'relationship',
         1 => 'scope',
         2 => 'accessor',

--- a/src/Linters/ModelMethodOrder.php
+++ b/src/Linters/ModelMethodOrder.php
@@ -29,9 +29,9 @@ class ModelMethodOrder extends BaseLinter
 
     private $tests;
 
-    public function __construct($code, $extension = '.php')
+    public function __construct($code, $filename = null)
     {
-        parent::__construct($code, $extension);
+        parent::__construct($code, $filename);
 
         $this->tests = [
             'scope' => Closure::fromCallable([$this, 'isScopeMethod']),

--- a/src/Linters/NoCompact.php
+++ b/src/Linters/NoCompact.php
@@ -8,9 +8,12 @@ use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsControllers;
 
 class NoCompact extends BaseLinter
 {
+    use LintsControllers;
+
     protected $description = 'There should be no calls to `compact()` in controllers';
 
     public function lint(Parser $parser)

--- a/src/Linters/NoDocBlocksForMigrationUpDown.php
+++ b/src/Linters/NoDocBlocksForMigrationUpDown.php
@@ -7,9 +7,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsMigrations;
 
 class NoDocBlocksForMigrationUpDown extends BaseLinter
 {
+    use LintsMigrations;
+
     protected $description = 'Remove doc blocks from the up and down method in migrations.';
 
     public function lint(Parser $parser)

--- a/src/Linters/NoJsonDirective.php
+++ b/src/Linters/NoJsonDirective.php
@@ -5,9 +5,12 @@ namespace Tighten\Linters;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
 use Tighten\CustomNode;
+use Tighten\Linters\Concerns\LintsBladeTemplates;
 
 class NoJsonDirective extends BaseLinter
 {
+    use LintsBladeTemplates;
+
     protected $description = 'Use blade `{{ $model }}` auto escaping for models, and double quotes via json_encode over @json blade directive:'
         . ' `<vue-comp :values=\'@json($var)\'>` -> `<vue-comp :values="{{ $model }}">` OR `<vue-comp :values="{{ json_encode($var) }}">`';
 

--- a/src/Linters/NoLeadingSlashesOnRoutePaths.php
+++ b/src/Linters/NoLeadingSlashesOnRoutePaths.php
@@ -7,9 +7,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsRoutesFiles;
 
 class NoLeadingSlashesOnRoutePaths extends BaseLinter
 {
+    use LintsRoutesFiles;
+
     protected $description = 'No leading slashes on route paths.';
 
     public function lint(Parser $parser)

--- a/src/Linters/NoMethodVisibilityInTests.php
+++ b/src/Linters/NoMethodVisibilityInTests.php
@@ -8,9 +8,12 @@ use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsTests;
 
 class NoMethodVisibilityInTests extends BaseLinter
 {
+    use LintsTests;
+
     protected $description = 'There should be no method visibility in test methods.';
 
     public function lint(Parser $parser)

--- a/src/Linters/NoSpaceAfterBladeDirectives.php
+++ b/src/Linters/NoSpaceAfterBladeDirectives.php
@@ -5,9 +5,12 @@ namespace Tighten\Linters;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
 use Tighten\CustomNode;
+use Tighten\Linters\Concerns\LintsBladeTemplates;
 
 class NoSpaceAfterBladeDirectives extends BaseLinter
 {
+    use LintsBladeTemplates;
+
     private const NO_SPACE_AFTER = [
         'endif',
         'else',

--- a/src/Linters/NoSpaceAfterBladeDirectives.php
+++ b/src/Linters/NoSpaceAfterBladeDirectives.php
@@ -11,7 +11,7 @@ class NoSpaceAfterBladeDirectives extends BaseLinter
 {
     use LintsBladeTemplates;
 
-    private const NO_SPACE_AFTER = [
+    protected const NO_SPACE_AFTER = [
         'endif',
         'else',
         'section',

--- a/src/Linters/PureRestControllers.php
+++ b/src/Linters/PureRestControllers.php
@@ -13,7 +13,7 @@ class PureRestControllers extends BaseLinter
 {
     use LintsControllers;
 
-    private const RESTFUL_METHOD_NAMES = [
+    protected const RESTFUL_METHOD_NAMES = [
         'index',
         'create',
         'store',
@@ -22,7 +22,7 @@ class PureRestControllers extends BaseLinter
         'update',
         'destroy',
     ];
-    private const IGNORED_METHOD_NAMES = [
+    protected const IGNORED_METHOD_NAMES = [
         'validator',
         '__construct',
     ];

--- a/src/Linters/PureRestControllers.php
+++ b/src/Linters/PureRestControllers.php
@@ -7,9 +7,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsControllers;
 
 class PureRestControllers extends BaseLinter
 {
+    use LintsControllers;
+
     private const RESTFUL_METHOD_NAMES = [
         'index',
         'create',

--- a/src/Linters/RequestHelperFunctionWherePossible.php
+++ b/src/Linters/RequestHelperFunctionWherePossible.php
@@ -7,9 +7,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsControllers;
 
 class RequestHelperFunctionWherePossible extends BaseLinter
 {
+    use LintsControllers;
+
     protected $description = 'Use the request(...) helper function directly to access request values wherever possible';
 
     public function lint(Parser $parser)

--- a/src/Linters/RequestValidation.php
+++ b/src/Linters/RequestValidation.php
@@ -8,9 +8,11 @@ use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
 use Tighten\Concerns\IdentifiesExtends;
+use Tighten\Linters\Concerns\LintsControllers;
 
 class RequestValidation extends BaseLinter
 {
+    use LintsControllers;
     use IdentifiesExtends;
 
     protected $description = 'Use `request()->validate(...)` helper function or extract a FormRequest instead of using'

--- a/src/Linters/RestControllersMethodOrder.php
+++ b/src/Linters/RestControllersMethodOrder.php
@@ -13,7 +13,7 @@ class RestControllersMethodOrder extends BaseLinter
 {
     use LintsControllers;
 
-    private const RESTFUL_METHOD_NAMES = [
+    protected const RESTFUL_METHOD_NAMES = [
         'index',
         'create',
         'store',

--- a/src/Linters/RestControllersMethodOrder.php
+++ b/src/Linters/RestControllersMethodOrder.php
@@ -7,9 +7,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsControllers;
 
 class RestControllersMethodOrder extends BaseLinter
 {
+    use LintsControllers;
+
     private const RESTFUL_METHOD_NAMES = [
         'index',
         'create',

--- a/src/Linters/SpaceAfterBladeDirectives.php
+++ b/src/Linters/SpaceAfterBladeDirectives.php
@@ -5,9 +5,12 @@ namespace Tighten\Linters;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
 use Tighten\CustomNode;
+use Tighten\Linters\Concerns\LintsBladeTemplates;
 
 class SpaceAfterBladeDirectives extends BaseLinter
 {
+    use LintsBladeTemplates;
+
     private const SPACE_AFTER = [
         'if',
         'elseif',

--- a/src/Linters/SpaceAfterBladeDirectives.php
+++ b/src/Linters/SpaceAfterBladeDirectives.php
@@ -11,7 +11,7 @@ class SpaceAfterBladeDirectives extends BaseLinter
 {
     use LintsBladeTemplates;
 
-    private const SPACE_AFTER = [
+    protected const SPACE_AFTER = [
         'if',
         'elseif',
         'for',

--- a/src/Linters/SpacesAroundBladeRenderContent.php
+++ b/src/Linters/SpacesAroundBladeRenderContent.php
@@ -5,9 +5,12 @@ namespace Tighten\Linters;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
 use Tighten\CustomNode;
+use Tighten\Linters\Concerns\LintsBladeTemplates;
 
 class SpacesAroundBladeRenderContent extends BaseLinter
 {
+    use LintsBladeTemplates;
+
     protected $description = 'Spaces around blade rendered content:'
         . '`{{1 + 1}}` -> `{{ 1 + 1 }}`';
 

--- a/src/Linters/UseAuthHelperOverFacade.php
+++ b/src/Linters/UseAuthHelperOverFacade.php
@@ -7,13 +7,27 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Illuminate\Compilers\BladeCompiler;
 use Tighten\Illuminate\Compilers\Concerns\CompilesConditionals;
+use Tighten\Linters\Concerns\LintsBladeTemplates;
 
 class UseAuthHelperOverFacade extends BaseLinter
 {
+    use LintsBladeTemplates;
     use CompilesConditionals;
 
     protected $description = 'Prefer the `auth()` helper function over the `Auth` Facade.';
+    
+    public function __construct($code, $filename = null)
+    {
+        if (preg_match('/\.blade\.php$/i', $filename)) {
+            $bladeCompiler = new BladeCompiler(null, sys_get_temp_dir());
+            $code = $bladeCompiler->compileString($code);
+        }
+        
+        parent::__construct($code, $filename);
+    }
+
 
     public function lint(Parser $parser)
     {

--- a/src/Linters/UseConfigOverEnv.php
+++ b/src/Linters/UseConfigOverEnv.php
@@ -7,9 +7,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsNonConfigFiles;
 
 class UseConfigOverEnv extends BaseLinter
 {
+    use LintsNonConfigFiles;
+
     protected $description = 'Don’t use environment variables directly; instead,'
         . ' use them in config files and call config vars from code';
 

--- a/src/Linters/ViewWithOverArrayParameters.php
+++ b/src/Linters/ViewWithOverArrayParameters.php
@@ -9,9 +9,21 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
+use Tighten\Linters\Concerns\LintsControllers;
+use Tighten\Linters\Concerns\LintsRoutesFiles;
 
 class ViewWithOverArrayParameters extends BaseLinter
 {
+    use LintsControllers, LintsRoutesFiles {
+        LintsControllers::appliesToPath as pathIsController;
+        LintsRoutesFiles::appliesToPath as pathIsRoute;
+    }
+
+    public static function appliesToPath(string $path): bool
+    {
+        return static::pathIsController($path) || static::pathIsRoute($path);
+    }
+
     protected $description = 'Prefer `view(...)->with(...)` over `view(..., [...])`.';
 
     public function lint(Parser $parser)

--- a/src/Presets/LaravelPreset.php
+++ b/src/Presets/LaravelPreset.php
@@ -35,4 +35,9 @@ class LaravelPreset implements PresetInterface
             'UseConfigOverEnv',
         ];
     }
+
+    public function getFormatters() : array
+    {
+        return [];
+    }
 }

--- a/src/Presets/LaravelPreset.php
+++ b/src/Presets/LaravelPreset.php
@@ -1,38 +1,65 @@
 <?php
 
 namespace Tighten\Presets;
+ 
+use Tighten\Linters\ApplyMiddlewareInRoutes;
+use Tighten\Linters\ArrayParametersOverViewWith;
+use Tighten\Linters\ClassThingsOrder;
+use Tighten\Linters\ImportFacades;
+use Tighten\Linters\MailableMethodsInBuild;
+use Tighten\Linters\ModelMethodOrder;
+use Tighten\Linters\NewLineAtEndOfFile;
+use Tighten\Linters\NoCompact;
+use Tighten\Linters\NoDd;
+use Tighten\Linters\NoLeadingSlashesOnRoutePaths;
+use Tighten\Linters\NoParensEmptyInstantiations;
+use Tighten\Linters\NoSpaceAfterBladeDirectives;
+use Tighten\Linters\NoStringInterpolationWithoutBraces;
+use Tighten\Linters\OneLineBetweenClassVisibilityChanges;
+use Tighten\Linters\PureRestControllers;
+use Tighten\Linters\QualifiedNamesOnlyForClassName;
+use Tighten\Linters\RemoveLeadingSlashNamespaces;
+use Tighten\Linters\RequestHelperFunctionWherePossible;
+use Tighten\Linters\RequestValidation;
+use Tighten\Linters\RestControllersMethodOrder;
+use Tighten\Linters\SpaceAfterBladeDirectives;
+use Tighten\Linters\SpaceAfterSoleNotOperator;
+use Tighten\Linters\SpacesAroundBladeRenderContent;
+use Tighten\Linters\TrailingCommasOnArrays;
+use Tighten\Linters\UseAuthHelperOverFacade;
+use Tighten\Linters\UseConfigOverEnv;
 
 class LaravelPreset implements PresetInterface
 {
     public function getLinters() : array
     {
         return [
-            'ApplyMiddlewareInRoutes',
-            'ArrayParametersOverViewWith',
-            'ClassThingsOrder',
-            'ImportFacades',
-            'MailableMethodsInBuild',
-            'ModelMethodOrder',
-            'NewLineAtEndOfFile',
-            'NoCompact',
-            'NoDd',
-            'NoLeadingSlashesOnRoutePaths',
-            'NoParensEmptyInstantiations',
-            'NoSpaceAfterBladeDirectives',
-            'NoStringInterpolationWithoutBraces',
-            'OneLineBetweenClassVisibilityChanges',
-            'PureRestControllers',
-            'QualifiedNamesOnlyForClassName',
-            'RemoveLeadingSlashNamespaces',
-            'RequestHelperFunctionWherePossible',
-            'RequestValidation',
-            'RestControllersMethodOrder',
-            'SpaceAfterBladeDirectives',
-            'SpaceAfterSoleNotOperator',
-            'SpacesAroundBladeRenderContent',
-            'TrailingCommasOnArrays',
-            'UseAuthHelperOverFacade',
-            'UseConfigOverEnv',
+            ApplyMiddlewareInRoutes::class,
+            ArrayParametersOverViewWith::class,
+            ClassThingsOrder::class,
+            ImportFacades::class,
+            MailableMethodsInBuild::class,
+            ModelMethodOrder::class,
+            NewLineAtEndOfFile::class,
+            NoCompact::class,
+            NoDd::class,
+            NoLeadingSlashesOnRoutePaths::class,
+            NoParensEmptyInstantiations::class,
+            NoSpaceAfterBladeDirectives::class,
+            NoStringInterpolationWithoutBraces::class,
+            OneLineBetweenClassVisibilityChanges::class,
+            PureRestControllers::class,
+            QualifiedNamesOnlyForClassName::class,
+            RemoveLeadingSlashNamespaces::class,
+            RequestHelperFunctionWherePossible::class,
+            RequestValidation::class,
+            RestControllersMethodOrder::class,
+            SpaceAfterBladeDirectives::class,
+            SpaceAfterSoleNotOperator::class,
+            SpacesAroundBladeRenderContent::class,
+            TrailingCommasOnArrays::class,
+            UseAuthHelperOverFacade::class,
+            UseConfigOverEnv::class,
         ];
     }
 

--- a/src/Presets/LaravelPreset.php
+++ b/src/Presets/LaravelPreset.php
@@ -2,64 +2,39 @@
 
 namespace Tighten\Presets;
  
-use Tighten\Linters\ApplyMiddlewareInRoutes;
-use Tighten\Linters\ArrayParametersOverViewWith;
-use Tighten\Linters\ClassThingsOrder;
-use Tighten\Linters\ImportFacades;
-use Tighten\Linters\MailableMethodsInBuild;
-use Tighten\Linters\ModelMethodOrder;
-use Tighten\Linters\NewLineAtEndOfFile;
-use Tighten\Linters\NoCompact;
-use Tighten\Linters\NoDd;
-use Tighten\Linters\NoLeadingSlashesOnRoutePaths;
-use Tighten\Linters\NoParensEmptyInstantiations;
-use Tighten\Linters\NoSpaceAfterBladeDirectives;
-use Tighten\Linters\NoStringInterpolationWithoutBraces;
-use Tighten\Linters\OneLineBetweenClassVisibilityChanges;
-use Tighten\Linters\PureRestControllers;
-use Tighten\Linters\QualifiedNamesOnlyForClassName;
-use Tighten\Linters\RemoveLeadingSlashNamespaces;
-use Tighten\Linters\RequestHelperFunctionWherePossible;
-use Tighten\Linters\RequestValidation;
-use Tighten\Linters\RestControllersMethodOrder;
-use Tighten\Linters\SpaceAfterBladeDirectives;
-use Tighten\Linters\SpaceAfterSoleNotOperator;
-use Tighten\Linters\SpacesAroundBladeRenderContent;
-use Tighten\Linters\TrailingCommasOnArrays;
-use Tighten\Linters\UseAuthHelperOverFacade;
-use Tighten\Linters\UseConfigOverEnv;
+use Tighten\Linters;
 
 class LaravelPreset implements PresetInterface
 {
     public function getLinters() : array
     {
         return [
-            ApplyMiddlewareInRoutes::class,
-            ArrayParametersOverViewWith::class,
-            ClassThingsOrder::class,
-            ImportFacades::class,
-            MailableMethodsInBuild::class,
-            ModelMethodOrder::class,
-            NewLineAtEndOfFile::class,
-            NoCompact::class,
-            NoDd::class,
-            NoLeadingSlashesOnRoutePaths::class,
-            NoParensEmptyInstantiations::class,
-            NoSpaceAfterBladeDirectives::class,
-            NoStringInterpolationWithoutBraces::class,
-            OneLineBetweenClassVisibilityChanges::class,
-            PureRestControllers::class,
-            QualifiedNamesOnlyForClassName::class,
-            RemoveLeadingSlashNamespaces::class,
-            RequestHelperFunctionWherePossible::class,
-            RequestValidation::class,
-            RestControllersMethodOrder::class,
-            SpaceAfterBladeDirectives::class,
-            SpaceAfterSoleNotOperator::class,
-            SpacesAroundBladeRenderContent::class,
-            TrailingCommasOnArrays::class,
-            UseAuthHelperOverFacade::class,
-            UseConfigOverEnv::class,
+            Linters\ApplyMiddlewareInRoutes::class,
+            Linters\ArrayParametersOverViewWith::class,
+            Linters\ClassThingsOrder::class,
+            Linters\ImportFacades::class,
+            Linters\MailableMethodsInBuild::class,
+            Linters\ModelMethodOrder::class,
+            Linters\NewLineAtEndOfFile::class,
+            Linters\NoCompact::class,
+            Linters\NoDd::class,
+            Linters\NoLeadingSlashesOnRoutePaths::class,
+            Linters\NoParensEmptyInstantiations::class,
+            Linters\NoSpaceAfterBladeDirectives::class,
+            Linters\NoStringInterpolationWithoutBraces::class,
+            Linters\OneLineBetweenClassVisibilityChanges::class,
+            Linters\PureRestControllers::class,
+            Linters\QualifiedNamesOnlyForClassName::class,
+            Linters\RemoveLeadingSlashNamespaces::class,
+            Linters\RequestHelperFunctionWherePossible::class,
+            Linters\RequestValidation::class,
+            Linters\RestControllersMethodOrder::class,
+            Linters\SpaceAfterBladeDirectives::class,
+            Linters\SpaceAfterSoleNotOperator::class,
+            Linters\SpacesAroundBladeRenderContent::class,
+            Linters\TrailingCommasOnArrays::class,
+            Linters\UseAuthHelperOverFacade::class,
+            Linters\UseConfigOverEnv::class,
         ];
     }
 

--- a/src/Presets/PresetInterface.php
+++ b/src/Presets/PresetInterface.php
@@ -5,4 +5,5 @@ namespace Tighten\Presets;
 interface PresetInterface
 {
     public function getLinters() : array;
+    public function getFormatters() : array;
 }

--- a/src/Presets/TightenPreset.php
+++ b/src/Presets/TightenPreset.php
@@ -2,85 +2,54 @@
 
 namespace Tighten\Presets;
 
-use Tighten\Linters\AlphabeticalImports;
-use Tighten\Linters\ApplyMiddlewareInRoutes;
-use Tighten\Linters\ArrayParametersOverViewWith;
-use Tighten\Linters\ClassThingsOrder;
-use Tighten\Linters\ConcatenationSpacing;
-use Tighten\Linters\ImportFacades;
-use Tighten\Linters\MailableMethodsInBuild;
-use Tighten\Linters\ModelMethodOrder;
-use Tighten\Linters\NewLineAtEndOfFile;
-use Tighten\Linters\NoCompact;
-use Tighten\Linters\NoDd;
-use Tighten\Linters\NoDocBlocksForMigrationUpDown;
-use Tighten\Linters\NoInlineVarDocs;
-use Tighten\Linters\NoLeadingSlashesOnRoutePaths;
-use Tighten\Linters\NoMethodVisibilityInTests;
-use Tighten\Linters\NoParensEmptyInstantiations;
-use Tighten\Linters\NoSpaceAfterBladeDirectives;
-use Tighten\Linters\NoStringInterpolationWithoutBraces;
-use Tighten\Linters\NoUnusedImports;
-use Tighten\Linters\OneLineBetweenClassVisibilityChanges;
-use Tighten\Linters\PureRestControllers;
-use Tighten\Linters\QualifiedNamesOnlyForClassName;
-use Tighten\Linters\RemoveLeadingSlashNamespaces;
-use Tighten\Linters\RequestHelperFunctionWherePossible;
-use Tighten\Linters\RequestValidation;
-use Tighten\Linters\RestControllersMethodOrder;
-use Tighten\Linters\SpaceAfterBladeDirectives;
-use Tighten\Linters\SpaceAfterSoleNotOperator;
-use Tighten\Linters\SpacesAroundBladeRenderContent;
-use Tighten\Linters\TrailingCommasOnArrays;
-use Tighten\Linters\UseAuthHelperOverFacade;
-use Tighten\Linters\UseConfigOverEnv;
-use Tighten\Linters\NoJsonDirective;
+use Tighten\Formatters;
+use Tighten\Linters;
 
 class TightenPreset implements PresetInterface
 {
     public function getLinters() : array
     {
         return [
-            AlphabeticalImports::class,
-            ApplyMiddlewareInRoutes::class,
-            ArrayParametersOverViewWith::class,
-            ClassThingsOrder::class,
-            ConcatenationSpacing::class,
-            ImportFacades::class,
-            MailableMethodsInBuild::class,
-            ModelMethodOrder::class,
-            NewLineAtEndOfFile::class,
-            NoCompact::class,
-            NoDd::class,
-            NoDocBlocksForMigrationUpDown::class,
-            NoInlineVarDocs::class,
-            NoLeadingSlashesOnRoutePaths::class,
-            NoMethodVisibilityInTests::class,
-            NoParensEmptyInstantiations::class,
-            NoSpaceAfterBladeDirectives::class,
-            NoStringInterpolationWithoutBraces::class,
-            NoUnusedImports::class,
-            OneLineBetweenClassVisibilityChanges::class,
-            PureRestControllers::class,
-            QualifiedNamesOnlyForClassName::class,
-            RemoveLeadingSlashNamespaces::class,
-            RequestHelperFunctionWherePossible::class,
-            RequestValidation::class,
-            RestControllersMethodOrder::class,
-            SpaceAfterBladeDirectives::class,
-            SpaceAfterSoleNotOperator::class,
-            SpacesAroundBladeRenderContent::class,
-            TrailingCommasOnArrays::class,
-            UseAuthHelperOverFacade::class,
-            UseConfigOverEnv::class,
-            NoJsonDirective::class,
+            Linters\AlphabeticalImports::class,
+            Linters\ApplyMiddlewareInRoutes::class,
+            Linters\ArrayParametersOverViewWith::class,
+            Linters\ClassThingsOrder::class,
+            Linters\ConcatenationSpacing::class,
+            Linters\ImportFacades::class,
+            Linters\MailableMethodsInBuild::class,
+            Linters\ModelMethodOrder::class,
+            Linters\NewLineAtEndOfFile::class,
+            Linters\NoCompact::class,
+            Linters\NoDd::class,
+            Linters\NoDocBlocksForMigrationUpDown::class,
+            Linters\NoInlineVarDocs::class,
+            Linters\NoLeadingSlashesOnRoutePaths::class,
+            Linters\NoMethodVisibilityInTests::class,
+            Linters\NoParensEmptyInstantiations::class,
+            Linters\NoSpaceAfterBladeDirectives::class,
+            Linters\NoStringInterpolationWithoutBraces::class,
+            Linters\NoUnusedImports::class,
+            Linters\OneLineBetweenClassVisibilityChanges::class,
+            Linters\PureRestControllers::class,
+            Linters\QualifiedNamesOnlyForClassName::class,
+            Linters\RemoveLeadingSlashNamespaces::class,
+            Linters\RequestHelperFunctionWherePossible::class,
+            Linters\RequestValidation::class,
+            Linters\RestControllersMethodOrder::class,
+            Linters\SpaceAfterBladeDirectives::class,
+            Linters\SpaceAfterSoleNotOperator::class,
+            Linters\SpacesAroundBladeRenderContent::class,
+            Linters\TrailingCommasOnArrays::class,
+            Linters\UseAuthHelperOverFacade::class,
+            Linters\UseConfigOverEnv::class,
+            Linters\NoJsonDirective::class,
         ];
     }
 
     public function getFormatters() : array
     {
         return [
-            AlphabeticalImports::class,
+            Formatters\AlphabeticalImports::class,
         ];
     }
 }

--- a/src/Presets/TightenPreset.php
+++ b/src/Presets/TightenPreset.php
@@ -2,51 +2,85 @@
 
 namespace Tighten\Presets;
 
+use Tighten\Linters\AlphabeticalImports;
+use Tighten\Linters\ApplyMiddlewareInRoutes;
+use Tighten\Linters\ArrayParametersOverViewWith;
+use Tighten\Linters\ClassThingsOrder;
+use Tighten\Linters\ConcatenationSpacing;
+use Tighten\Linters\ImportFacades;
+use Tighten\Linters\MailableMethodsInBuild;
+use Tighten\Linters\ModelMethodOrder;
+use Tighten\Linters\NewLineAtEndOfFile;
+use Tighten\Linters\NoCompact;
+use Tighten\Linters\NoDd;
+use Tighten\Linters\NoDocBlocksForMigrationUpDown;
+use Tighten\Linters\NoInlineVarDocs;
+use Tighten\Linters\NoLeadingSlashesOnRoutePaths;
+use Tighten\Linters\NoMethodVisibilityInTests;
+use Tighten\Linters\NoParensEmptyInstantiations;
+use Tighten\Linters\NoSpaceAfterBladeDirectives;
+use Tighten\Linters\NoStringInterpolationWithoutBraces;
+use Tighten\Linters\NoUnusedImports;
+use Tighten\Linters\OneLineBetweenClassVisibilityChanges;
+use Tighten\Linters\PureRestControllers;
+use Tighten\Linters\QualifiedNamesOnlyForClassName;
+use Tighten\Linters\RemoveLeadingSlashNamespaces;
+use Tighten\Linters\RequestHelperFunctionWherePossible;
+use Tighten\Linters\RequestValidation;
+use Tighten\Linters\RestControllersMethodOrder;
+use Tighten\Linters\SpaceAfterBladeDirectives;
+use Tighten\Linters\SpaceAfterSoleNotOperator;
+use Tighten\Linters\SpacesAroundBladeRenderContent;
+use Tighten\Linters\TrailingCommasOnArrays;
+use Tighten\Linters\UseAuthHelperOverFacade;
+use Tighten\Linters\UseConfigOverEnv;
+use Tighten\Linters\NoJsonDirective;
+
 class TightenPreset implements PresetInterface
 {
     public function getLinters() : array
     {
         return [
-            'AlphabeticalImports',
-            'ApplyMiddlewareInRoutes',
-            'ArrayParametersOverViewWith',
-            'ClassThingsOrder',
-            'ConcatenationSpacing',
-            'ImportFacades',
-            'MailableMethodsInBuild',
-            'ModelMethodOrder',
-            'NewLineAtEndOfFile',
-            'NoCompact',
-            'NoDd',
-            'NoDocBlocksForMigrationUpDown',
-            'NoInlineVarDocs',
-            'NoLeadingSlashesOnRoutePaths',
-            'NoMethodVisibilityInTests',
-            'NoParensEmptyInstantiations',
-            'NoSpaceAfterBladeDirectives',
-            'NoStringInterpolationWithoutBraces',
-            'NoUnusedImports',
-            'OneLineBetweenClassVisibilityChanges',
-            'PureRestControllers',
-            'QualifiedNamesOnlyForClassName',
-            'RemoveLeadingSlashNamespaces',
-            'RequestHelperFunctionWherePossible',
-            'RequestValidation',
-            'RestControllersMethodOrder',
-            'SpaceAfterBladeDirectives',
-            'SpaceAfterSoleNotOperator',
-            'SpacesAroundBladeRenderContent',
-            'TrailingCommasOnArrays',
-            'UseAuthHelperOverFacade',
-            'UseConfigOverEnv',
-            'NoJsonDirective',
+            AlphabeticalImports::class,
+            ApplyMiddlewareInRoutes::class,
+            ArrayParametersOverViewWith::class,
+            ClassThingsOrder::class,
+            ConcatenationSpacing::class,
+            ImportFacades::class,
+            MailableMethodsInBuild::class,
+            ModelMethodOrder::class,
+            NewLineAtEndOfFile::class,
+            NoCompact::class,
+            NoDd::class,
+            NoDocBlocksForMigrationUpDown::class,
+            NoInlineVarDocs::class,
+            NoLeadingSlashesOnRoutePaths::class,
+            NoMethodVisibilityInTests::class,
+            NoParensEmptyInstantiations::class,
+            NoSpaceAfterBladeDirectives::class,
+            NoStringInterpolationWithoutBraces::class,
+            NoUnusedImports::class,
+            OneLineBetweenClassVisibilityChanges::class,
+            PureRestControllers::class,
+            QualifiedNamesOnlyForClassName::class,
+            RemoveLeadingSlashNamespaces::class,
+            RequestHelperFunctionWherePossible::class,
+            RequestValidation::class,
+            RestControllersMethodOrder::class,
+            SpaceAfterBladeDirectives::class,
+            SpaceAfterSoleNotOperator::class,
+            SpacesAroundBladeRenderContent::class,
+            TrailingCommasOnArrays::class,
+            UseAuthHelperOverFacade::class,
+            UseConfigOverEnv::class,
+            NoJsonDirective::class,
         ];
     }
 
     public function getFormatters() : array
     {
         return [
-            'AlphabeticalImports',
+            AlphabeticalImports::class,
         ];
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -23,9 +23,7 @@ class ConfigTest extends TestCase
     {
         $config = new Config(['disabled' => ['AlphabeticalImports']]);
 
-        $this->assertArrayNotHasKey(AlphabeticalImports::class, $config->filterLinters([
-            AlphabeticalImports::class => '.php',
-        ]));
+        $this->assertNotContains(AlphabeticalImports::class, $config->getLinters());
     }
 
     /** @test */

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Tighten\Config;
 use Tighten\Linters\AlphabeticalImports;
 use Tighten\Presets\LaravelPreset;
+use Tighten\Presets\PresetInterface;
 use Tighten\Presets\TightenPreset;
 
 class ConfigTest extends TestCase
@@ -32,5 +33,26 @@ class ConfigTest extends TestCase
         $config = new Config(null);
 
         $this->assertInstanceOf(TightenPreset::class, $config->getPreset());
+    }
+
+    /** @test */
+    function a_custom_preset_can_be_provided()
+    {
+        $config = new Config(['preset' => ConfigTestPreset::class]);
+
+        $this->assertInstanceOf(ConfigTestPreset::class, $config->getPreset());
+    }
+}
+
+class ConfigTestPreset implements PresetInterface
+{
+    public function getLinters(): array
+    {
+        return [];
+    }
+    
+    public function getFormatters(): array
+    {
+        return [];
     }
 }


### PR DESCRIPTION
We're looking into using `tlint` but have slightly different linting needs. Originally I was just going to fork the project, but it was fairly simple to add custom preset support via a moderate refactor. Before I spend much more time cleaning things up add adding tests, I wanted to get feedback on if this is something you're willing to merge in.

Changes of note:

- Rather than using the `getRoutesFilesLinters`/etc methods, I've added a static method called `appliesToPath` to all Linters. This way, the linter can determine if it applies, and the command logic is simplified down to an `array_filter` call. Traits are provided, like `LintsRoutesFiles`, so that common filtering can be re-used (all the existing filters are re-implemented as traits).

- Because custom presets need to be able to publish custom linters or formatters, I've inverted the logic around filtering. The preset + config become responsible for defining the linters that should be applied, and then the command just filters those that are enabled by whether they apply to a given file.

- The `extension` parameter was only being used in one linter (`UseAuthHelperOverFacade`) to determine if the code needed to be compiled from blade. I refactored things so that the whole filename is provided to the linter, and updated `UseAuthHelperOverFacade` to compile the code if necessary. This simplified a number of the other changes.

- I had to update logic in a number of places that assumed all classes were in the Tighten namespace. As a result, it probably makes sense to just switch to fully qualified class names instead. I'm happy to do that but want to keep the diff of this as minimal as possible at first.

- Right now a lot of things are marked as `private` which makes extending them for our own use difficult. A good example is that our code standards keep the `boot` method at the top of the file. Ideally, we'd just extend `ModelMethodOrder` and update the `METHOD_ORDER` constant and use that in our custom preset. The `private` keyword prevents that. How do you feel about me swapping out the private keyword where protected would make more sense to allow for extension?

An example of an custom config file would just be:

```json
{
  "preset": "App\\Support\\Linting\\AppPreset",
  "disabled": [
    "App\\Support\\Linting\\Linters\\MyCustomLinter",
    "AlphabeticalImports"
  ],
  "excluded": [
    "tests/"
  ]
}
```

You can still use the `"laravel"` or `"tighten"` preset and that will work, and if you don't provide a full class name it will automatically normalize it to `Tighten\Linters` or `Tighten\Formatters` for you.