### PR TITLE
Get all code lines in NoStringInterpolationWithoutBraces

### DIFF
--- a/src/Linters/NoStringInterpolationWithoutBraces.php
+++ b/src/Linters/NoStringInterpolationWithoutBraces.php
@@ -20,12 +20,12 @@ class NoStringInterpolationWithoutBraces extends BaseLinter
             if ($node instanceof Node\Scalar\Encapsed) {
                 foreach ($node->parts as $part) {
                     if ($part instanceof Node\Expr\Variable) {
-                        $line = $this->getCodeLine($node->getStartLine());
+                        $line = $this->getCodeLinesFromNode($node);
                         $name = $part->name;
 
                         return ! (strpos($line, "{\${$name}}") !== false);
                     } elseif ($part instanceof Node\Expr\PropertyFetch) {
-                        $line = $this->getCodeLine($node->getStartLine());
+                        $line = $this->getCodeLinesFromNode($node);
                         $propertyFetchString = $this->constructPropertyFetchString($part);
 
                         return ! (strpos($line, "{\${$propertyFetchString}") !== false);


### PR DESCRIPTION
The `NoStringInterpolationWithoutBraces` linter currently only checks the first line of code that it's linting. This means:

```php
$demo = "Hello darkness,
my old {$friendOrEnemy}";
```

Will fail, even though it's properly using braces.

This fixes that by loading all the code lines for the node into the test.