### PR TITLE
Add support for Group Use Declarations to ImportFacades linter

### DIFF
--- a/src/Linters/ImportFacades.php
+++ b/src/Linters/ImportFacades.php
@@ -61,7 +61,11 @@ class ImportFacades extends BaseLinter
 
             static $useNames = [];
 
-            if ($node instanceof Node\Stmt\UseUse) {
+            if ($node instanceof Node\Stmt\GroupUse) {
+                foreach ($node->uses as $use) {
+                    $useNames[] = Node\Name::concat($node->prefix, $use->name)->toString();
+                }
+            } elseif ($node instanceof Node\Stmt\UseUse) {
                 $useNames[] = $node->name->toString();
             }
 

--- a/tests/Linting/Linters/ImportFacadesTest.php
+++ b/tests/Linting/Linters/ImportFacadesTest.php
@@ -63,6 +63,27 @@ file;
     }
 
     /** @test */
+    function does_not_trigger_on_facade_usage_with_grouped_import()
+    {
+        $file = <<<file
+<?php
+
+namespace Test;
+
+use Illuminate\Support\Facades\{Config, Hash};
+
+var_dump(Config::get('test'));
+var_dump(Hash::make('test'));
+file;
+
+        $lints = (new TLint)->lint(
+            new ImportFacades($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
     function does_not_throw_on_variable_class_static_calls()
     {
         $file = <<<file

--- a/tests/Linting/Linters/ImportFacadesTest.php
+++ b/tests/Linting/Linters/ImportFacadesTest.php
@@ -52,7 +52,7 @@ namespace Test;
 
 use Illuminate\Support\Facades\Hash;
 
-var_dump(Hash::make('test'));
+Hash::make('test');
 file;
 
         $lints = (new TLint)->lint(
@@ -72,8 +72,7 @@ namespace Test;
 
 use Illuminate\Support\Facades\{Config, Hash};
 
-var_dump(Config::get('test'));
-var_dump(Hash::make('test'));
+Config::get('test');
 file;
 
         $lints = (new TLint)->lint(


### PR DESCRIPTION
I want to use this project on my code, but one issue I noticed is that the linter ImportFacades didn't have support for grouped use declarations (see the test for an example). To address this, I updated the linter to support this PHP 7 import syntax.

A new test has been added to verify this works (the diff might look a little odd since it's mostly copy-paste).