### PR TITLE
Handling edge case for ImportFacades linter where class is named the same as a Laravel facade

### DIFF
--- a/src/Linters/ImportFacades.php
+++ b/src/Linters/ImportFacades.php
@@ -5,6 +5,7 @@ namespace Tighten\Linters;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
+use PhpParser\Node\Name;
 use PhpParser\Parser;
 use Tighten\BaseLinter;
 
@@ -60,19 +61,23 @@ class ImportFacades extends BaseLinter
             }
 
             static $useNames = [];
+            static $useAliases = [];
 
             if ($node instanceof Node\Stmt\GroupUse) {
                 foreach ($node->uses as $use) {
-                    $useNames[] = Node\Name::concat($node->prefix, $use->name)->toString();
+                    $useNames[] = Name::concat($node->prefix, $use->name)->toString();
+                    $useAliases[] = $use->getAlias();
                 }
             } elseif ($node instanceof Node\Stmt\UseUse) {
                 $useNames[] = $node->name->toString();
+                $useAliases[] = $node->getAlias();
             }
 
             return $node instanceof Node\Expr\StaticCall
                 && $hasNamespace
                 && $node->class instanceof Node\Name
                 && in_array($node->class->toString(), array_keys(static::$aliases))
+                && ! in_array($node->class->toString(), $useAliases)
                 && ! in_array(static::$aliases[$node->class->toString()], $useNames);
         });
 

--- a/tests/Linting/Linters/ImportFacadesTest.php
+++ b/tests/Linting/Linters/ImportFacadesTest.php
@@ -63,6 +63,46 @@ file;
     }
 
     /** @test */
+    function does_not_trigger_on_facade_usage_with_nova_import()
+    {
+        $file = <<<file
+<?php
+
+namespace Test;
+
+use Laravel\Nova\Fields\Password;
+
+Password::make('Password');
+file;
+
+        $lints = (new TLint)->lint(
+            new ImportFacades($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
+    function does_not_trigger_on_facade_usage_with_custom_aliased_import()
+    {
+        $file = <<<file
+<?php
+
+namespace Test;
+
+use MyNamespace\MyClass as Config;
+
+Config::get('test');
+file;
+
+        $lints = (new TLint)->lint(
+            new ImportFacades($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
     function does_not_trigger_on_facade_usage_with_grouped_import()
     {
         $file = <<<file


### PR DESCRIPTION
In continuing to use the linter in my codebase, I came across another interesting bug.

With the following code, the linter will pick this up as an issue because it thinks that I didn't import the Password facade, when really I'm trying to use a class that happens to be named the same as the facade.

```php
use Laravel\Nova\Fields\Password;
Password::make('Password');
```

To address this, I had to start tracking the "alias" for a `use` statement, which is just the last part of the qualified import (`Password`) if there's no `as` keyword after the name, or the name after the `as` keyword if it is included on an import.

The linter class will now verify the class used is not just a name that overlaps with one of the Laravel facades before marking it as an un-imported alias.

P.S. - I ran `tlint` on its own codebase, and it flagged up the issue "Fully Qualified Class Names should only be used for accessing class names" for the usage of `Node\Name` so I made it into an import, now no linter failures occur.