### PR TITLE
Fix false positives for NoUnusedImports with typed properties

### DIFF
--- a/src/Concerns/IdentifiesImports.php
+++ b/src/Concerns/IdentifiesImports.php
@@ -56,7 +56,7 @@ trait IdentifiesImports
                         $used[] = $implemented->toString();
                     }, $node->implements);
                 }
-            } elseif ($node instanceof Node\Param
+            } elseif (($node instanceof Node\Param || $node instanceof Node\Stmt\Property)
                 && $node->type instanceof Node\Name
                 && property_exists($node, 'type')
             ) {

--- a/tests/Linting/Linters/NoUnusedImportsTest.php
+++ b/tests/Linting/Linters/NoUnusedImportsTest.php
@@ -378,4 +378,26 @@ file;
 
         $this->assertEmpty($lints);
     }
+
+    /** @test */
+    function does_not_trigger_when_used_in_class_property_typehint()
+    {
+        $file = <<<file
+<?php
+
+use App\Job;
+
+class Test
+{
+    public Job \$job;
+}
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoUnusedImports($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 }


### PR DESCRIPTION
Similarly to #80, when using typed properties that were introduced in PHP 7.4, TLint didn't recognize this as a used import.