### PR TITLE
Improving logic of IdentifiesImports to support interfaces, static property calls, and nullable types

### DIFF
--- a/src/Concerns/IdentifiesImports.php
+++ b/src/Concerns/IdentifiesImports.php
@@ -44,6 +44,8 @@ trait IdentifiesImports
                 $used[] = $node->class->toString();
             } elseif ($node instanceof Node\Expr\StaticCall && $node->class instanceof Node\Name) {
                 $used[] = $node->class->toString();
+            } elseif ($node instanceof Node\Expr\StaticPropertyFetch && $node->class instanceof Node\Name) {
+                $used[] = $node->class->toString();
             } elseif ($node instanceof Node\Expr\ClassConstFetch && $node->class instanceof Node\Name) {
                 $used[] = $node->class->toString();
             } elseif ($node instanceof Node\Stmt\Class_) {
@@ -56,11 +58,22 @@ trait IdentifiesImports
                         $used[] = $implemented->toString();
                     }, $node->implements);
                 }
+            } elseif ($node instanceof Node\Stmt\Interface_) {
+                foreach ($node->extends as $name) {
+                    if ($name instanceof Node\Name) {
+                        $used[] = $name->toString();
+                    }
+                }
             } elseif (($node instanceof Node\Param || $node instanceof Node\Stmt\Property)
-                && $node->type instanceof Node\Name
                 && property_exists($node, 'type')
             ) {
-                $used[] = $node->type->toString();
+                $type = $node->type;
+                if ($type instanceof Node\NullableType) {
+                    $type = $type->type;
+                }
+                if ($type instanceof Node\Name) {
+                    $used[] = $type->toString();
+                }
             } elseif ($node instanceof Node\Stmt\Catch_ && property_exists($node, 'types')) {
                 foreach ($node->types as $type) {
                     $used[] = $type->toString();

--- a/tests/Linting/Linters/NoUnusedImportsTest.php
+++ b/tests/Linting/Linters/NoUnusedImportsTest.php
@@ -241,6 +241,27 @@ file;
     }
 
     /** @test */
+    function does_not_trigger_on_interface_import()
+    {
+        $file = <<<file
+<?php
+
+use Test\ThingA;
+
+interface Thing extends ThingA
+{
+}
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoUnusedImports($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
     function does_not_trigger_when_import_is_used_as_an_interface_along_with_extends()
     {
         $file = <<<file
@@ -330,6 +351,28 @@ file;
     }
 
     /** @test */
+    function does_not_trigger_when_used_in_static_property_fetch()
+    {
+        $file = <<<file
+<?php
+
+use App\Job;
+
+function test()
+{
+    echo Job::TYPES;
+}
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoUnusedImports($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
     function handles_instanceof_for_dynamic_expressions()
     {
         $file = <<<file
@@ -340,6 +383,30 @@ class Test
     function test(\$a, \$b)
     {
         return \$a instanceof \$b;
+    }
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new NoUnusedImports($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
+    function handles_nullable_parameters()
+    {
+        $file = <<<file
+<?php
+
+use App\Job;
+
+class Test
+{
+    function test(?Job \$j)
+    {
+        return \$j ?? false;
     }
 }
 file;


### PR DESCRIPTION
While trying out the unused import detector, I found it didn't pick up usages of quite a few different imports, so when I used the formatter, it removed some lines it shouldn't have.

This PR adds detection for (see tests for cases of each):

1. Interfaces extending other interfaces (`extends`)
2. Fetching a static property (`Class::VALUE`)
3. Nullable types on a function (`?Class` as an argument datatype, instead of `Class`)

With these changes, I no longer got unused import errors for the above usages, and also verified via new passing unit tests.