### PR TITLE
Fix return code when using --json

### DIFF
--- a/src/Commands/LintCommand.php
+++ b/src/Commands/LintCommand.php
@@ -56,7 +56,7 @@ class LintCommand extends BaseCommand
         if ($this->isBlacklisted($file)) {
             return self::NO_LINTS_FOUND_OR_SUCCESS;
         }
-        
+
         $linters = $this->getLinters($file);
 
         if (! empty($only = $input->getOption('only'))) {
@@ -117,7 +117,7 @@ class LintCommand extends BaseCommand
             'errors' => $errors,
         ]));
 
-        return self::LINTS_FOUND_OR_ERROR;
+        return self::NO_LINTS_FOUND_OR_SUCCESS;
     }
 
     private function outputLints(OutputInterface $output, $file, $lints)
@@ -141,6 +141,8 @@ class LintCommand extends BaseCommand
 
             return self::LINTS_FOUND_OR_ERROR;
         }
+
+        $output->writeLn('LGTM!');
 
         return self::NO_LINTS_FOUND_OR_SUCCESS;
     }
@@ -239,13 +241,9 @@ class LintCommand extends BaseCommand
             return self::LINTS_FOUND_OR_ERROR;
         }
 
-        if ($finalResponseCode === self::NO_LINTS_FOUND_OR_SUCCESS) {
-            $output->writeLn('LGTM!');
-        }
-
         return $finalResponseCode;
     }
-    
+
     private function getLinters($path)
     {
         return array_filter($this->config->getLinters(), function($className) use ($path) {

--- a/tests/Linting/CanOutputLintsAsJsonTest.php
+++ b/tests/Linting/CanOutputLintsAsJsonTest.php
@@ -11,7 +11,7 @@ use Tighten\Linters\ConcatenationSpacing;
 class CanOutputLintsAsJsonTest extends TestCase
 {
     /** @test */
-    function can_use_json_flag()
+    function can_use_json_flag_with_lints()
     {
         $application = new Application;
         $command = new LintCommand;
@@ -45,6 +45,37 @@ file;
             ],
         ], json_decode($commandTester->getDisplay(), true));
 
-        $this->assertEquals(1, $commandTester->getStatusCode());
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+    /** @test */
+    function can_use_json_flag_without_lints()
+    {
+        $application = new Application;
+        $command = new LintCommand;
+        $application->add($command);
+        $commandTester = new CommandTester($command);
+
+        $file = <<<file
+<?php
+
+echo 'a';
+
+file;
+
+        $filePath = tempnam(sys_get_temp_dir(), 'test');
+
+        file_put_contents($filePath, $file);
+
+        $commandTester->execute([
+            'command'  => $command->getName(),
+            'file or directory' => $filePath,
+            '--json' => true,
+        ]);
+
+        $this->assertEquals([
+            'errors' => [],
+        ], json_decode($commandTester->getDisplay(), true));
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
     }
 }


### PR DESCRIPTION
The VSCode tlint intergation requires the return code of tlint to be 0.
Since v3.0.9 tlint always returns 1 which prevents lints showing in VSCode

This reverts the return code to be 0 and amends tests to ensure this behaviour
when lints/no lints

Fixes #135