### PR TITLE
Fix duplicate LGTM messages

### DIFF
--- a/src/Commands/LintCommand.php
+++ b/src/Commands/LintCommand.php
@@ -142,8 +142,6 @@ class LintCommand extends BaseCommand
             return self::LINTS_FOUND_OR_ERROR;
         }
 
-        $output->writeLn('LGTM!');
-
         return self::NO_LINTS_FOUND_OR_SUCCESS;
     }
 
@@ -239,6 +237,16 @@ class LintCommand extends BaseCommand
             $output->writeln('No file or directory found at ' . $input->getArgument('file or directory'));
 
             return self::LINTS_FOUND_OR_ERROR;
+        }
+
+
+        if($input->getOption('json')) {
+            return self::NO_LINTS_FOUND_OR_SUCCESS;
+        }
+
+
+        if($finalResponseCode === self::NO_LINTS_FOUND_OR_SUCCESS) {
+            $output->writeLn('LGTM!');
         }
 
         return $finalResponseCode;


### PR DESCRIPTION
Following the changes merged in #136 a regression was introduced
which output `LGTM` for every file when the command was run on a
directory.  This change reverts the original behaviour to only
print `LGTM` once but does not output the message in `json` mode
to prevent issues with `json_decode`