### PR TITLE
Fix visibility of inherited constant

### DIFF
--- a/src/Commands/FormatCommand.php
+++ b/src/Commands/FormatCommand.php
@@ -19,8 +19,8 @@ use Tighten\TFormat;
 
 class FormatCommand extends BaseCommand
 {
-    private const SUCCESS = 0;
-    private const ERROR = 1;
+    public const SUCCESS = 0;
+    public const ERROR = 1;
     private $thereWasChange = false;
 
     protected function configure()


### PR DESCRIPTION
Symfony 5.1 added the `SUCCESS` and `FAILURE` constants to their Command class.

Because the same name `SUCCESS` is used here, I got the following error:

```
PHP Fatal error:  Access level to Tighten\Commands\FormatCommand::SUCCESS must be public (as in class Tighten\Commands\BaseCommand) in /home/runner/.composer/vendor/tightenco/tlint/src/Commands/FormatCommand.php on line 221
```

I would suggest changing the constants' visibility to public, which will also still work with Symfony versions prior to 5.1.