### PR TITLE
Adding support for nullable return typehints in import detection

### DIFF
--- a/src/Concerns/IdentifiesImports.php
+++ b/src/Concerns/IdentifiesImports.php
@@ -89,14 +89,24 @@ trait IdentifiesImports
                 $used[] = $node->name->toString();
             } elseif ($node instanceof Node\Stmt\ClassMethod
                 && property_exists($node, 'returnType')
-                && $node->returnType instanceof Node\Name
             ) {
-                $used[] = $node->returnType->toString();
+                if ($node->returnType instanceof Node\Name) {
+                    $used[] = $node->returnType->toString();
+                } elseif ($node->returnType instanceof Node\NullableType
+                    && $node->returnType->type instanceof Node\Name
+                ) {
+                    $used[] = $node->returnType->type->toString();
+                }
             } elseif ($node instanceof Node\Stmt\Function_
                 && property_exists($node, 'returnType')
-                && $node->returnType instanceof Node\Name
             ) {
-                $used[] = $node->returnType->toString();
+                if ($node->returnType instanceof Node\Name) {
+                    $used[] = $node->returnType->toString();
+                } elseif ($node->returnType instanceof Node\NullableType
+                    && $node->returnType->type instanceof Node\Name
+                ) {
+                    $used[] = $node->returnType->type->toString();
+                }
             }
 
             return false;

--- a/tests/Linting/Linters/NoUnusedImportsTest.php
+++ b/tests/Linting/Linters/NoUnusedImportsTest.php
@@ -329,6 +329,31 @@ file;
     }
 
     /** @test */
+    function does_not_trigger_when_used_in_class_method_return_nullable_typehint()
+    {
+        $file = <<<file
+<?php
+
+use App\User;
+
+class Test
+{
+    public function test() : ?User
+    {
+        //
+    }
+}
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoUnusedImports($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
     function does_not_trigger_when_used_in_function_return_typehint()
     {
         $file = <<<file
@@ -337,6 +362,28 @@ file;
 use App\Job;
 
 function test() : Job
+{
+    //
+}
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoUnusedImports($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
+    function does_not_trigger_when_used_in_function_return_nullable_typehint()
+    {
+        $file = <<<file
+<?php
+
+use App\User;
+
+function test() : ?User
 {
     //
 }


### PR DESCRIPTION
I found a bug with the unused import detection, this time with nullable typehints. The previous logic only supported standard `foo(): ClassName` typehints, not the `foo(): ?ClassName` syntax in PHP 7.1+.

This adds new logic to support both kinds, and adds tests to prove it works.