### PR TITLE
Fix crash on dynamic method calls

### DIFF
--- a/src/Formatters/RequestValidation.php
+++ b/src/Formatters/RequestValidation.php
@@ -78,6 +78,10 @@ class RequestValidation extends BaseFormatter
                     return null;
                 }
 
+                if (! $node->name instanceof Node\Identifier) {
+                    return null;
+                }
+
                 if ($node->name->name !== 'validate') {
                     return null;
                 }

--- a/src/Linters/NoRequestAll.php
+++ b/src/Linters/NoRequestAll.php
@@ -15,10 +15,26 @@ class NoRequestAll extends BaseLinter
     protected function visitor(): Closure
     {
         return function (Node $node) {
-            $isRequestMethodCall = $node instanceof MethodCall && (string) $node->var->name === 'request';
-            $isRequestStaticCall = $node instanceof StaticCall && (string) $node->class === 'Request';
+            $isRequestCall = match (true) {
+                $node instanceof MethodCall
+                    && $node->var instanceof Node\Expr\Variable
+                    && $node->var->name === 'request',
 
-            return ($isRequestMethodCall || $isRequestStaticCall) && $node->name->name === 'all';
+                $node instanceof MethodCall
+                    && $node->var instanceof Node\Expr\FuncCall
+                    && $node->var->name instanceof Node\Name
+                    && $node->var->name->toString() === 'request',
+
+                $node instanceof StaticCall
+                    && $node->class instanceof Node\Name
+                    && $node->class->toString() === 'Request' => true,
+
+                default => false,
+            };
+
+            return $isRequestCall
+                && $node->name instanceof Node\Identifier
+                && $node->name->name === 'all';
         };
     }
 }

--- a/src/Linters/RequestHelperFunctionWherePossible.php
+++ b/src/Linters/RequestHelperFunctionWherePossible.php
@@ -17,6 +17,7 @@ class RequestHelperFunctionWherePossible extends BaseLinter
     {
         return function (Node $node) {
             return $node instanceof Node\Expr\MethodCall
+                && $node->name instanceof Node\Identifier
                 && $node->name->name === 'get'
                 && $node->var instanceof Node\Expr\FuncCall
                 && $node->var->name->toString() === 'request';

--- a/src/Linters/RequestValidation.php
+++ b/src/Linters/RequestValidation.php
@@ -27,6 +27,7 @@ class RequestValidation extends BaseLinter
             return $node instanceof Node\Expr\MethodCall
                 && $node->var instanceof Node\Expr\Variable
                 && $node->var->name === 'this'
+                && $node->name instanceof Node\Identifier
                 && $node->name->name === 'validate';
         });
 

--- a/tests/Formatting/Formatters/RequestValidationTest.php
+++ b/tests/Formatting/Formatters/RequestValidationTest.php
@@ -136,4 +136,28 @@ class RequestValidationTest extends TestCase
 
         $this->assertSame($file, $formatted);
     }
+
+    /** @test */
+    public function does_not_throw_on_dynamic_method_calls()
+    {
+        $file = <<<'file'
+            <?php
+
+            namespace App;
+
+            use App\Http\Controllers\Controller;
+
+            class ControllerA extends Controller
+            {
+                public function foo(string $p)
+                {
+                    return $this->{'get' . $p}();
+                }
+            }
+            file;
+
+        $formatted = (new TFormat)->format(new RequestValidation($file));
+
+        $this->assertSame($file, $formatted);
+    }
 }

--- a/tests/Linting/Linters/NoRequestAllTest.php
+++ b/tests/Linting/Linters/NoRequestAllTest.php
@@ -103,4 +103,50 @@ class NoRequestAllTest extends TestCase
 
         $this->assertEmpty($lints);
     }
+
+    /** @test */
+    public function does_not_throw_on_dynamic_method_calls()
+    {
+        $file = <<<'file'
+            <?php
+
+            namespace App\Http\Controllers;
+
+            class UserController
+            {
+                public function foo($request, string $p)
+                {
+                    return $request->{'a' . $p}();
+                }
+            }
+            file;
+
+        $lints = (new TLint)->lint(new NoRequestAll($file));
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
+    public function does_not_throw_on_non_stringable_receivers()
+    {
+        $file = <<<'file'
+            <?php
+
+            namespace App\Http\Controllers;
+
+            class UserController
+            {
+                public function foo($resolver, $class, $name)
+                {
+                    $resolver()->all();
+                    $class::all();
+                    ${$name}->all();
+                }
+            }
+            file;
+
+        $lints = (new TLint)->lint(new NoRequestAll($file));
+
+        $this->assertEmpty($lints);
+    }
 }

--- a/tests/Linting/Linters/RequestHelperFunctionWherePossibleTest.php
+++ b/tests/Linting/Linters/RequestHelperFunctionWherePossibleTest.php
@@ -48,4 +48,28 @@ class RequestHelperFunctionWherePossibleTest extends TestCase
 
         $this->assertEmpty($lints);
     }
+
+    /** @test */
+    public function does_not_throw_on_dynamic_method_calls()
+    {
+        $file = <<<'file'
+            <?php
+
+            namespace App;
+
+            class Probe
+            {
+                public function foo($item, string $p): string
+                {
+                    return (string) $item->{'get' . $p}();
+                }
+            }
+            file;
+
+        $lints = (new TLint)->lint(
+            new RequestHelperFunctionWherePossible($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 }

--- a/tests/Linting/Linters/RequestValidationTest.php
+++ b/tests/Linting/Linters/RequestValidationTest.php
@@ -106,4 +106,28 @@ class RequestValidationTest extends TestCase
 
         $this->assertEmpty($lints);
     }
+
+    /** @test */
+    public function does_not_throw_on_dynamic_method_calls()
+    {
+        $file = <<<'file'
+            <?php
+
+            namespace App;
+
+            class ControllerA extends Controller
+            {
+                public function foo($item, string $p): string
+                {
+                    return (string) $this->{'get' . $p}();
+                }
+            }
+            file;
+
+        $lints = (new TLint)->lint(
+            new RequestValidation($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes crashing on dynamic method calls
- Adds `$node->name instanceof Node\Identifier` guard before dereferencing `->name->name` in affected rules

### Notes
Based onto [PR](https://github.com/tighten/tlint/pull/384) since previous tagged brought upon some small linting fixes

Closes #382